### PR TITLE
Fix formatting not happening with hardware keyboard

### DIFF
--- a/PaymentKit Droid/src/com/paymentkit/views/CardNumEditText.java
+++ b/PaymentKit Droid/src/com/paymentkit/views/CardNumEditText.java
@@ -64,12 +64,6 @@ public class CardNumEditText extends EditText {
 	private TextEvent mLastEvent = TextEvent.KEY_PRESS;
 
 	@Override
-	public boolean onKeyDown(int keyCode, KeyEvent event) {
-		mLastEvent = TextEvent.KEY_PRESS;
-		return super.onKeyDown(keyCode, event);
-	}
-	
-	@Override
 	public void onDraw(Canvas canvas) {
 		super.onDraw(canvas);
 	}
@@ -87,6 +81,9 @@ public class CardNumEditText extends EditText {
 				formatText(getText().toString().replaceAll(" ", ""));
 				positionCursor(curPos);
 			}
+			if (mLastEvent != TextEvent.KEY_PRESS) {
+                		mLastEvent = TextEvent.KEY_PRESS;
+        		}
 		}
 		
 		private void formatText(String strippedStr) {


### PR DESCRIPTION
In fact, Samsung is so bad, that the numerical keyboard on a Galaxy S3 phone under Android 4.3 is considered a Hardware Keyboard, the onKeyDown event was not fired. This fix make this lib works on every Android phone and version.
