### PR TITLE
Add basic ability to override style

### DIFF
--- a/pKExample/src/main/java/me/brendanweinstein/pkexample/PKFragment.java
+++ b/pKExample/src/main/java/me/brendanweinstein/pkexample/PKFragment.java
@@ -42,7 +42,7 @@ public class PKFragment extends Fragment {
   private OnClickListener mSaveBtnListener = new OnClickListener() {
     @Override
     public void onClick(View v) {
-      ViewUtils.hideSoftKeyboard(getActivity());
+      ViewUtils.hideSoftKeyboard(v);
       if (mFieldHolder.isFieldsValid()) {
         ToastUtils.showToast(getActivity(), "Valid credit card entry!");
       } else {

--- a/pk-library/src/main/java/me/brendanweinstein/util/ViewUtils.java
+++ b/pk-library/src/main/java/me/brendanweinstein/util/ViewUtils.java
@@ -21,10 +21,11 @@ public class ViewUtils {
 	private static final int LAYER_TYPE_NONE = 0;
 	private static final int LAYER_TYPE_SOFTWARE = 1;
 	
-	public static void hideSoftKeyboard(final Activity activity) {
-		if (activity.getCurrentFocus() != null) {
-			final InputMethodManager imm = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
-			imm.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+	public static void hideSoftKeyboard(final View view) {
+		if (view != null) {
+			Context context = view.getContext();
+			final InputMethodManager imm = (InputMethodManager) context.getSystemService(context.INPUT_METHOD_SERVICE);
+			imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
 		}
 	}
 

--- a/pk-library/src/main/java/me/brendanweinstein/views/CVVEditText.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/CVVEditText.java
@@ -1,6 +1,5 @@
 package me.brendanweinstein.views;
 
-import android.app.Activity;
 import android.content.Context;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -49,7 +48,7 @@ public class CVVEditText extends EditText {
 	                event.getAction() == KeyEvent.ACTION_DOWN &&
 	                event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
 	        	clearFocus();
-	        	ViewUtils.hideSoftKeyboard((Activity)getContext());
+	        	ViewUtils.hideSoftKeyboard(CVVEditText.this);
 	            return true;
 	        }
 	        return false;
@@ -115,7 +114,7 @@ public class CVVEditText extends EditText {
 		public void afterTextChanged(Editable s) {
 			if (s.length() == FieldHolder.CVV_MAX_LENGTH) {
 				//mListener.onCVVEntryComplete();
-				ViewUtils.hideSoftKeyboard((Activity)getContext());
+				ViewUtils.hideSoftKeyboard(CVVEditText.this);
 				clearFocus();
 			}
 		}

--- a/pk-library/src/main/java/me/brendanweinstein/views/CardNumEditText.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/CardNumEditText.java
@@ -79,7 +79,6 @@ public class CardNumEditText extends EditText {
 	TextWatcher mCardNumberTextWatcher = new TextWatcher() {
 		@Override
 		public void afterTextChanged(Editable s) {
-			setTextColor(Color.DKGRAY);
 			mCardEntryListener.onEdit();
 			if (length() == mMaxCardLength && mTextAdded) {
 				mCardEntryListener.onCardNumberInputComplete();

--- a/pk-library/src/main/java/me/brendanweinstein/views/CardNumHolder.java
+++ b/pk-library/src/main/java/me/brendanweinstein/views/CardNumHolder.java
@@ -134,7 +134,6 @@ public class CardNumHolder extends RelativeLayout {
 		mLeftOffset = fullWidth - fourDigitsWidth;
 		ViewUtils.setMarginLeft(mLastFourDigits, (int) mLeftOffset);
 		// align digits on right
-		mLastFourDigits.setTextColor(Color.DKGRAY);
 		mLastFourDigits.setVisibility(View.VISIBLE);
 	}
 

--- a/pk-library/src/main/res/values/styles.xml
+++ b/pk-library/src/main/res/values/styles.xml
@@ -22,6 +22,7 @@
 	</style>
 
 	<style name="PKAddCardField">
+		<item name="android:textColor">#FF444444</item>
 		<item name="android:textSize">16sp</item>
 		<item name="android:inputType">number</item>
 		<item name="android:background">@null</item>


### PR DESCRIPTION
Fixes #18 and #19.

Basically allows the implementing app to override styling a bit:

```
    <style name="PKAddCardField">
        <item name="android:textSize">20sp</item>
        <item name="android:textColor">#FFFFFF</item>
        <item name="android:inputType">number</item>
        <item name="android:background">@null</item>
        <item name="fontPath">fonts/proximanovasoft-semibold.otf</item>
    </style>
```

That last line is for Calligraphy. :)
